### PR TITLE
any files in /public automatically have kemal routes created for them…

### DIFF
--- a/bfs.cr
+++ b/bfs.cr
@@ -1,0 +1,7 @@
+require "baked_file_system"
+class PublicStorage
+  BakedFileSystem.load("./public/",__DIR__)
+end
+
+
+puts PublicStorage.files.map &.path

--- a/public/js/test.txt
+++ b/public/js/test.txt
@@ -1,0 +1,1 @@
+this is a test

--- a/src/lattice-core/application.cr
+++ b/src/lattice-core/application.cr
@@ -1,8 +1,12 @@
+require "./public_storage"  # this is required early so the files are loaded.
 module Lattice::Core
   class Application
 
-    get "/js/app.js" do |context|
-      PublicStorage.get("/js/app.js").read
+    # create a kemal route for every file in PublicStorage
+    PublicStorage.files.each do |file|
+      get file.path do |context|
+        PublicStorage.get(file.path).read
+      end
     end
 
     ws "/connected_object" do |socket|


### PR DESCRIPTION
… and served with BakedFileStorage.

A challenge is presented by having a library that needs static files.  Kemal will by default serve them out of the /public directory, but this presents a problem since our files are in lib/lattice-core/public and completely invisible to kemal.

This fixes that problem by using [schovi/baked_file_system](https://github.com/schovi/baked_file_system).   It reads the library's public directory and files, and creates a kemal route for each path it finds.  Conveniently, any file in the public directory of an app that uses lattice-core can replace these built-in files by simply placing them in the public directory of the app.