### PR TITLE
Socket javascript

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,14 +1,3 @@
-// document.addEventListener("DOMContentLoaded", function(evt) {
-//     // Do stuff...
-//   document.getElementById("hand").addEventListener("click", function(evt) {
-//     id = evt.target.id;
-//     // FIXME Need to figure out a way to encapsulate js var name (cardgameSocket)
-//     cardgameSocket.send(JSON.stringify({"act":{"click":id}}))
-//   })
-// });
-
-
-
 function handleSocketMessage(message) {
   payload = JSON.parse(message);
   if ("dom" in payload) {
@@ -16,20 +5,28 @@ function handleSocketMessage(message) {
   }
 }
 
+
 function modifyDOM(domData) {
-  if (el = document.getElementById(domData.id)) {
-    console.log(domData)
-    switch (domData.action) {
-      case "update":
-        el.innerHTML = domData.value
-        break;
-      case "delete":
-        el.parentNode.removeChild(el)
-        break;
-      case "insert":
-        el.insertAdjacentHTML('beforeend',domData.value)
-        break;
-    }
+  if (matches = document.querySelectorAll("#" + domData.id)) {
+    for (var i=0; i<matches.length; i++) {
+      el = matches[i];
+      switch (domData.action) {
+        case "update":
+          el.innerHTML = domData.value
+          break;
+        case "update_attribute":
+          el.setAttribute(domData.attribute, domData.value)
+          break;
+        case "attribute":
+          el.innerHTML = domData.value
+          break;
+        case "delete":
+          el.parentNode.removeChild(el)
+          break;
+        case "insert":
+          el.insertAdjacentHTML('beforeend',domData.value)
+          break;
+      }}
     el.closest("[data-version]").setAttribute("data-version",domData.version)
   } else {
       console.log("cound not locate element " + domData.id)

--- a/src/lattice-core/connected/web_object.cr
+++ b/src/lattice-core/connected/web_object.cr
@@ -17,6 +17,12 @@ module Lattice::Connected
     def content
     end
 
+    def update_attribute( change : Hash(String,String | Int32) )
+      self.version +=1
+      msg = { "dom"=>change.merge({"action"=>"update_attribute", "version"=>version}) }
+      subscribers.each &.send(msg.to_json)
+    end
+
     def update( change : Hash(String,String | Int32) )
       self.version +=1
       msg = { "dom"=>change.merge({"action"=>"update", "version"=>version}) }
@@ -81,6 +87,10 @@ module Lattice::Connected
     # and the element ids to which to subscribe.
     # It then creates event listeners for actions on subscribed objects, currently
     # just click events (more will come)
+    # FIXME we have a problem right now when the same object is on the page twice: it only
+    # updates one of them since document.getElementById only returns the first match.
+    # this can be solved by using a class instead of an id (so cardgame-12312-card-2 is the
+    # class, not the id.
     def self.javascript(session_id : String, target : _)
       javascript = <<-JS
         #{js_var} = new WebSocket("ws:" + location.host + "/connected_object");

--- a/src/lattice-core/connected/web_socket.cr
+++ b/src/lattice-core/connected/web_socket.cr
@@ -100,6 +100,7 @@ module Lattice::Connected
         WebObject::INSTANCES[id].subscribe(socket)
       end
       memory_used
+
     end
 
     # a debugging aid to show how much data we have laying around
@@ -117,7 +118,11 @@ module Lattice::Connected
     # OPTIMIZE this should also be used by extract_ids
     def self.extract_id( from : String)
       numbers = from.gsub(/[^0-9]+/,' ').squeeze(' ').strip.split(" ")
-      numbers.map(&.to_u64).sort.last
+      begin
+        numbers.map(&.to_u64).sort.last
+      rescue
+        nil
+      end
     end
 
     # When an incoming message arrives, it must be from a particular object that has
@@ -129,11 +134,11 @@ module Lattice::Connected
       # not just the one that was acted upon.
       
       # find the object for which the action happens
-      id = extract_id( action_data.first_key)
-      puts "id from #{action_data.first_key} is #{id}".colorize(:yellow)
-      acted_object = WebObject::INSTANCES[id]
-      session_id = REGISTERED_SESSIONS[socket.object_id]?
-      acted_object.subscriber_action(action_data, session_id)
+      if ( id = extract_id( action_data.first_key) )
+        acted_object = WebObject::INSTANCES[id]
+        session_id = REGISTERED_SESSIONS[socket.object_id]?
+        acted_object.subscriber_action(action_data, session_id)
+      end
       # subscribed_to(socket).each_value do |subscribed_object|
       #   session_id = REGISTERED_SESSIONS[socket.object_id]?
       #   subscribed_object.subscriber_action(action_data, session_id)


### PR DESCRIPTION
Made a fairly substantial number of changes to handle javascript better:
* Events (addEventHandler) now added within javascript provided by web_socket.cr, which
 abstracts more of it away from day-to-day use.
* Multiple copies of the same object now update.   All copies of an object use the same id, (div id=123), but document.getElementById only returned the first match, as javascript expects only one object with the same id on page.  However, switching handler code to use querySelectorAll and looping through the results allows us to bypass this issue.
* updatable items under a dom_id of an object now are expected to have ids that are composites of dom_id and its own index.  For example, "cardgame-1234-card-2" rather than simply "card-2"