### PR TITLE
Better signature calculation and INSTANCE storage

### DIFF
--- a/src/lattice-core/base62.cr
+++ b/src/lattice-core/base62.cr
@@ -1,0 +1,46 @@
+class Base62
+
+  class ArgumentError < Exception; end
+  ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  BASE = ALPHABET.size.to_u64
+
+  # Creates a base62 digest of a given string.
+  # ```
+  # string_digest = Base62.string_digest("Hi Bob")  # "a8t1hFHyM"`
+  # string_digest = Base62.string_digest("Hi Bob")  # 2213222356800000
+  # 
+	def self.string_digest( target : String) : String
+    sha_digest = Digest::SHA1.digest target
+    encode sha_digest.first(8).reduce(1_u64) {|o,i| o*i}
+  end
+
+  # returns the UInt64 equivalent
+  def self.int_digest( target : String) : UInt64
+      sha_digest = Digest::SHA1.digest target
+    	sha_digest.first(8).reduce(1_u64) {|o,i| o*i}
+	end
+
+  # decodes a string_digest to an int
+  def self.decode(base_val : String) : UInt64
+    int_val = 0_u64
+    base_val.reverse.split(//).each_with_index do |char,index|
+      raise ArgumentError.new "Value passed not a valid Base58 String." unless ALPHABET.index(char)
+      int_val +=( ALPHABET.index(char).as(Int32).to_u64 *   BASE**(index)  ).to_u64 
+    end
+    int_val
+  end
+
+  # encodes UInt64 into a base62 string
+  def self.encode(int_val : UInt64) : String
+    base_val = ""
+    while(int_val >= BASE)
+      mod = int_val % BASE
+      base_val = ALPHABET[mod,1] + base_val
+      int_val = (int_val - mod)/BASE
+    end
+    ALPHABET[int_val,1] + base_val
+  end
+  
+  
+end
+


### PR DESCRIPTION
Changed how `WebObject::INSTANCES` instances are stored.   Since a dom_id is ultimately a digest of some form, there's a concern that a collision could occur (imagine setting the digest length for card_game to 1 character; you'd only be able to have a maximum of 16 games (0-F), and a 50% chance of a collision at 8 games).

Previously, some substring of a SHA1 hash (from the name, among other things) was used as a key.    Since the string's object_id is used internally by the `Hash(String,self)`, it meant, ultimately, that a `UInt64` was stored.  With 8 characters of the 40-character hash, 20% of the hash was captured.  The greater the number, the less likely a hash collision occurs.

INSTANCES are now a Hash(UInt64,self) with a new calculation for the key.  The new class Base62 digests a string into a UInt64 (Hash Key) or String (Dom Signature).  It works out that this consumes 40%  (64 bits of 160 SHA1 digest bits), exactly double.   Since a SHA1 digest _should_ have perfect entropy, that means the UInt64 used as the key should also have perfect entropy.

If my math is right, the chances of a hash collision are now  ` (maximum size of a UInt64) * 0.40 /  (number of WebObjects instantiated)`.  Suppose we have a server with a million objects instantiated; the calculation would be 3,689,348,814,741,910,528 / 1,000,000 = 3,689,348,814,742.  

I think that's good enough to stop worrying about the length.
